### PR TITLE
Add syntax highlighting for comments

### DIFF
--- a/grammars/atomiix.cson
+++ b/grammars/atomiix.cson
@@ -58,4 +58,10 @@
     'match': '(\\w+\\s+\\(\\()|(\\w+\\s+\\)\\))'
     'name': 'variable.parameter.atomiix'
   }
+
+  # comments
+  {
+    'match': '\\/\\*[\\s\\S]*?\\*\\/|([^\\\\:]|^)\\/\\/.*$'
+    'name': 'comment.atomiix'
+  }
 ]


### PR DESCRIPTION
I used JS syntax for this because it's what I use in the OG version even though it doesn't recognise comments. Open to changes! 